### PR TITLE
Add more dialogue options

### DIFF
--- a/Assets/Scenes/Master.unity
+++ b/Assets/Scenes/Master.unity
@@ -215,11 +215,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1804179836}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 40, y: -3}
+  m_AnchoredPosition: {x: 40, y: -57}
   m_SizeDelta: {x: 480, y: 260}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &115986122
@@ -399,7 +399,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &118173581
 Transform:
   m_ObjectHideFlags: 0
@@ -407,12 +407,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 118173580}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: -3.64, z: 0}
+  m_LocalScale: {x: 2.3514, y: 2.3514, z: 2.3514}
   m_Children: []
-  m_Father: {fileID: 2009051868}
-  m_RootOrder: 7
+  m_Father: {fileID: 1533977255}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &118173582
 BoxCollider2D:
@@ -1388,7 +1388,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1354598641008157257, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -155.50002
+      value: -155.50003
       objectReference: {fileID: 0}
     - target: {fileID: 1388845009926107339, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1664,7 +1664,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1721180100097064915, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -155.49979
+      value: -155.50002
       objectReference: {fileID: 0}
     - target: {fileID: 1721180100879851248, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1755,6 +1755,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 599316933}
     - target: {fileID: 1734841767755010747, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
+      propertyPath: DialogueChoiceTitle
+      value: 
+      objectReference: {fileID: 939986317}
+    - target: {fileID: 1734841767755010747, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: DialogueChoiceButton1
       value: 
       objectReference: {fileID: 912303422}
@@ -1770,6 +1774,10 @@ PrefabInstance:
       propertyPath: DialogueChoiceButton4
       value: 
       objectReference: {fileID: 525816059}
+    - target: {fileID: 1734841767755010747, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
+      propertyPath: DialogueChoiceButtonNext
+      value: 
+      objectReference: {fileID: 1862393312}
     - target: {fileID: 1741809014646436603, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4740,7 +4748,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7158153601728116312, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -155.49982
+      value: -155.50002
       objectReference: {fileID: 0}
     - target: {fileID: 7181473068942135630, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6020,6 +6028,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
+--- !u!224 &167534185 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9032590423878928170, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
+  m_PrefabInstance: {fileID: 167534184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &185726864
 GameObject:
   m_ObjectHideFlags: 0
@@ -6147,7 +6160,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &240210531
 Transform:
   m_ObjectHideFlags: 0
@@ -6155,12 +6168,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 240210530}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: -1.79, z: 0}
+  m_LocalScale: {x: 6.4144, y: 6.4144, z: 6.4144}
   m_Children: []
-  m_Father: {fileID: 2009051868}
-  m_RootOrder: 6
+  m_Father: {fileID: 1533977255}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &240210532
 MonoBehaviour:
@@ -6460,7 +6473,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -354, y: -189}
+  m_AnchoredPosition: {x: -354, y: -206}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &525816061
@@ -6550,7 +6563,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2009051868}
+    m_TransformParent: {fileID: 1787172844}
     m_Modifications:
     - target: {fileID: 2419816002067204258, guid: f36ea2cc21b714673a8641b8fc4c6dfe, type: 3}
       propertyPath: m_Name
@@ -6574,7 +6587,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8367631440745114260, guid: f36ea2cc21b714673a8641b8fc4c6dfe, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8367631440745114260, guid: f36ea2cc21b714673a8641b8fc4c6dfe, type: 3}
       propertyPath: m_LocalScale.x
@@ -6586,7 +6599,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8367631440745114260, guid: f36ea2cc21b714673a8641b8fc4c6dfe, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.03
+      value: 4.67
       objectReference: {fileID: 0}
     - target: {fileID: 8367631440745114260, guid: f36ea2cc21b714673a8641b8fc4c6dfe, type: 3}
       propertyPath: m_LocalPosition.y
@@ -6723,11 +6736,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1804179836}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 40, y: 2}
+  m_AnchoredPosition: {x: 40, y: -14}
   m_SizeDelta: {x: 480, y: 260}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &599316935
@@ -24633,6 +24646,140 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1882938eb764f4cb4a65f0b0aeea346d, type: 3}
+--- !u!1 &871776148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 871776149}
+  - component: {fileID: 871776151}
+  - component: {fileID: 871776150}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &871776149
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871776148}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1862393313}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &871776150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871776148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Next
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &871776151
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871776148}
+  m_CullTransparentMesh: 1
 --- !u!1001 &893763533
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24731,7 +24878,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -354, y: 104}
+  m_AnchoredPosition: {x: -354, y: 30}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &912303424
@@ -24816,6 +24963,264 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 912303422}
   m_CullTransparentMesh: 1
+--- !u!1 &939986317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 939986318}
+  - component: {fileID: 939986320}
+  - component: {fileID: 939986319}
+  m_Layer: 5
+  m_Name: ChoiceFieldTitle
+  m_TagString: UI_DialogueSpeechText
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &939986318
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939986317}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1804179836}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 40, y: 18}
+  m_SizeDelta: {x: 480, y: 260}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &939986319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939986317}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 290.915}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &939986320
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 939986317}
+  m_CullTransparentMesh: 1
+--- !u!1 &991227736
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 991227737}
+  - component: {fileID: 991227738}
+  - component: {fileID: 991227739}
+  - component: {fileID: 991227740}
+  m_Layer: 0
+  m_Name: Isometric Diamond
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &991227737
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 991227736}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.644, y: 3.611, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1787172844}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &991227738
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 991227736}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 843830771
+  m_SortingLayer: 8
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 3625043607559282579, guid: 19fb86013d8c24d6cb8410c0aadf30fa, type: 3}
+  m_Color: {r: 0, g: 0.40517235, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 0.5}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &991227739
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 991227736}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.026821613, y: 0.013410926}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 0.5}
+    newSize: {x: 1, y: 0.5}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.3620939, y: 0.78162885}
+  m_EdgeRadius: 0
+--- !u!114 &991227740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 991227736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 173c1e9a6ade34238a345732113e1359, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactionIndicatorUI: {fileID: 386472983}
 --- !u!1 &1003423790
 GameObject:
   m_ObjectHideFlags: 0
@@ -24852,7 +25257,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -354, y: -91}
+  m_AnchoredPosition: {x: -354, y: -128}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1003423792
@@ -25357,11 +25762,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1804179836}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 40, y: 7}
+  m_AnchoredPosition: {x: 40, y: -65}
   m_SizeDelta: {x: 480, y: 260}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1301730886
@@ -25798,6 +26203,39 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 9032590422797189316, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
   m_PrefabInstance: {fileID: 167534184}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1533977254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1533977255}
+  m_Layer: 0
+  m_Name: StoryTools
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1533977255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1533977254}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.77, y: -1.68, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2064792128}
+  - {fileID: 240210531}
+  - {fileID: 118173581}
+  m_Father: {fileID: 2009051868}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1538436958
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26082,7 +26520,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -354, y: 6}
+  m_AnchoredPosition: {x: -354, y: -49}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1678328366
@@ -26229,6 +26667,38 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4689181878842158263, guid: 38529195c28f74974919862c59afbdc0, type: 3}
   m_PrefabInstance: {fileID: 1718741275}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1787172843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1787172844}
+  m_Layer: 0
+  m_Name: NPCs
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1787172844
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787172843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 574567595}
+  - {fileID: 991227737}
+  m_Father: {fileID: 2009051868}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1797499242
 GameObject:
   m_ObjectHideFlags: 0
@@ -26521,6 +26991,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 939986318}
   - {fileID: 1301730885}
   - {fileID: 115986121}
   - {fileID: 1889140127}
@@ -26704,6 +27175,127 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1824295105}
   m_CullTransparentMesh: 1
+--- !u!1 &1862393312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1862393313}
+  - component: {fileID: 1862393316}
+  - component: {fileID: 1862393315}
+  - component: {fileID: 1862393314}
+  m_Layer: 5
+  m_Name: NextButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1862393313
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862393312}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 871776149}
+  m_Father: {fileID: 167534185}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -651, y: -448}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1862393314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862393312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1862393315}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1862393315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862393312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1862393316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862393312}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1879191305
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26796,11 +27388,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1804179836}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 40, y: -4}
+  m_AnchoredPosition: {x: 40, y: -39}
   m_SizeDelta: {x: 480, y: 260}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1889140128
@@ -27252,10 +27844,8 @@ Transform:
   - {fileID: 709040286}
   - {fileID: 230620237}
   - {fileID: 1110209562}
-  - {fileID: 574567595}
-  - {fileID: 2064792128}
-  - {fileID: 240210531}
-  - {fileID: 118173581}
+  - {fileID: 1533977255}
+  - {fileID: 1787172844}
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -27342,7 +27932,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2064792128
 Transform:
   m_ObjectHideFlags: 0
@@ -27350,12 +27940,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2064792127}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2009051868}
-  m_RootOrder: 5
+  m_Father: {fileID: 1533977255}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &2064792129
 SpriteRenderer:

--- a/Assets/Scenes/Master.unity
+++ b/Assets/Scenes/Master.unity
@@ -5996,7 +5996,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9032590423438073529, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9032590424220098865, guid: 66be39b48147c4f328337955a7fb7d36, type: 3}
       propertyPath: m_IsActive

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -16,6 +16,8 @@ namespace Game.Story
         [SerializeField] GameObject dialogueScreen;
         [SerializeField] GameObject dialogueBox;
         [SerializeField] GameObject DialogueChoices;
+        [SerializeField] GameObject DialogueChoiceButtonNext;
+        [SerializeField] GameObject DialogueChoiceTitle;
         [SerializeField] GameObject DialogueChoiceButton1;
         [SerializeField] GameObject DialogueChoiceButton2;
         [SerializeField] GameObject DialogueChoiceButton3;
@@ -96,31 +98,48 @@ namespace Game.Story
         private void ShowText(CutSceneDestinationIdentifier cutSceneDestinationIdentifier, bool isMonster, DialogueVariant variant) {
             dialogueChoice = 0;
             String[] dialogue = gameDialogue.getDialogue(GameScene.Instance.currentScene, GameScene.Instance.currentStage, cutSceneDestinationIdentifier, isMonster, variant);
+            System.Action[] actions = gameDialogue.getActions(GameScene.Instance.currentScene, GameScene.Instance.currentStage, cutSceneDestinationIdentifier, isMonster, variant);
 
             // Normal Dialogue Text
-            if (dialogue.Length == 1) {
+            if (dialogue != null && dialogue.Length == 1) {
                 DialogueChoices.SetActive(false);
                 DialogueText.SetActive(true);
 
                 TMP_Text textBox = DialogueText.GetComponent<TMP_Text>();
                 textBox.text = dialogue[0];
+
+                // If there should be a next button
+                if (actions != null && actions.Length > 0) {
+                    DialogueChoiceButtonNext.SetActive(true);
+
+                    Button next = DialogueChoiceButtonNext.GetComponent<Button>();
+                    next.onClick.AddListener(() => {
+                        GameScene.Instance.AdvanceStage();
+                        RefreshDialogue(cutSceneDestinationIdentifier, isMonster, variant);
+                    });
+                }
+                else {
+                    DialogueChoiceButtonNext.SetActive(false);
+                }
             }
 
             // Choices
             else {
                 DialogueChoices.SetActive(true);
                 DialogueText.SetActive(false);
-
-                System.Action[] actions = gameDialogue.getActions(GameScene.Instance.currentScene, GameScene.Instance.currentStage, cutSceneDestinationIdentifier, isMonster, variant);
+                DialogueChoiceButtonNext.SetActive(false);
 
                 /*for(int i = 0; i < dialogue.Length; i++) {
                     Debug.Log("Dialogue:" + dialogue[i]);
                 }*/
 
-                if (dialogue[0] != null) {
+                TMP_Text title =  DialogueChoiceTitle.GetComponent<TMP_Text>();
+                title.text = dialogue[0];
+
+                if (dialogue.Length > 1) {
                     DialogueChoiceButton1.SetActive(true);
                     TMP_Text choice1 =  DialogueChoiceText1.GetComponent<TMP_Text>();
-                    choice1.text = dialogue[0];
+                    choice1.text = dialogue[1];
                     Button button1 = DialogueChoiceButton1.GetComponent<Button>();
                     button1.onClick.AddListener(() => {
                         actions[0]();
@@ -133,10 +152,10 @@ namespace Game.Story
                     DialogueChoiceButton1.SetActive(false);
                 }
 
-                if (dialogue[1] != null) {
+                if (dialogue.Length > 2) {
                     DialogueChoiceButton2.SetActive(true);
                     TMP_Text choice2 =  DialogueChoiceText2.GetComponent<TMP_Text>();
-                    choice2.text = dialogue[1];
+                    choice2.text = dialogue[2];
                     Button button2 = DialogueChoiceButton2.GetComponent<Button>();
                     button2.onClick.AddListener(() => {
                         actions[1]();
@@ -149,10 +168,10 @@ namespace Game.Story
                     DialogueChoiceButton2.SetActive(false);
                 }
 
-                if (dialogue[2] != null) {
+                if (dialogue.Length > 3) {
                     DialogueChoiceButton3.SetActive(true);
                     TMP_Text choice3 =  DialogueChoiceText3.GetComponent<TMP_Text>();
-                    choice3.text = dialogue[2];
+                    choice3.text = dialogue[3];
                     Button button3 = DialogueChoiceButton3.GetComponent<Button>();
                     button3.onClick.AddListener(() => {
                         actions[2]();
@@ -165,10 +184,10 @@ namespace Game.Story
                     DialogueChoiceButton3.SetActive(false);
                 }
 
-                if (dialogue[3] != null) {
+                if (dialogue.Length > 4) {
                     DialogueChoiceButton4.SetActive(true);
                     TMP_Text choice4 =  DialogueChoiceText4.GetComponent<TMP_Text>();
-                    choice4.text = dialogue[3];
+                    choice4.text = dialogue[4];
                     Button button4 = DialogueChoiceButton4.GetComponent<Button>();
                     button4.onClick.AddListener(() => {
                         actions[3]();

--- a/Assets/Scripts/Dialogue/DialogueText.cs
+++ b/Assets/Scripts/Dialogue/DialogueText.cs
@@ -10,25 +10,44 @@ namespace Game.Story
       Dictionary<string, System.Action[]> actions = new Dictionary<string, System.Action[]>();
       Dictionary<string, string[]> text = new Dictionary<string, string[]>();
 
+      System.Action[] nextAction = new System.Action[] {() => {}};
+
       public GameDialogue() {
         initDialogue();
       }
 
       public System.Action[] getActions(GameScenes scene, GameStages stage, CutSceneDestinationIdentifier npc, bool isMonster = false, DialogueVariant variant = DialogueVariant.DV_01) {
-        return actions[getKey(scene, stage, npc, isMonster, variant)];
+        //Useful for debugging
+        // Debug.Log("Who is the NPC??: " + npc);
+        // Debug.Log("Action Key: " + getKey(scene, stage, npc, isMonster, variant));
+  
+        try {
+          return actions[getKey(scene, stage, npc, isMonster, variant)];
+        }
+        catch {
+          return null;
+        }
       }
 
       public string[] getDialogue(GameScenes scene, GameStages stage, CutSceneDestinationIdentifier npc, bool isMonster = false, DialogueVariant variant = DialogueVariant.DV_01) {
         //Useful for debugging
         // Debug.Log("Who is the NPC??: " + npc);
-        // Debug.Log("Key: " + getKey(scene, stage, npc, isMonster, variant));
-        
-        //return dict[getKey(scene, stage, npc, variant, false)];
-        return text[getKey(scene, stage, npc, isMonster, variant)];
+        // Debug.Log("Dialogue Key: " + getKey(scene, stage, npc, isMonster, variant));
+
+        try {
+          return text[getKey(scene, stage, npc, isMonster, variant)];
+        }
+        catch {
+          return null;
+        }
       }
 
       public string getKey(GameScenes scene, GameStages stage, CutSceneDestinationIdentifier npc, bool isMonster = false, DialogueVariant variant = DialogueVariant.DV_01) {
-        return $"{scene.ToString()}-{stage.ToString()}-{npc.ToString()}-{isMonster.ToString()}-{variant.ToString()}";
+        string key = $"{scene.ToString()}-{stage.ToString()}-{npc.ToString()}-{isMonster.ToString()}-{variant.ToString()}";
+
+        // Debug.Log("Get Key: " + key);
+
+        return key;
       }
 
       /*
@@ -36,6 +55,62 @@ namespace Game.Story
       */
 
       private void initDialogue() {
+        scene01();
+
+        testDialogue();
+
+        //Useful for debugging
+        /*Debug.Log("KEYS:");
+        foreach (string key in text.Keys) {
+          Debug.Log(key);
+        }*/
+      }
+
+      private void setDialogue(string key, string[] dialogue, System.Action[] dialogueActions = null) {
+        text.Add(key, dialogue);
+
+        if (dialogueActions != null) {
+          actions.Add(key, dialogueActions);
+        }
+      }
+
+      private void scene01() {
+        // GUARD
+
+        setDialogue(getKey(
+          GameScenes.Scene_01,
+          GameStages.Stage_01,
+          CutSceneDestinationIdentifier.Guard),
+          new string[] {"Welcome to Goldfleece, traveler! We aren't a large town, or a safe one, or a rich one, but you're here now!"},
+          nextAction // Optionally advance the conversation to the next stage.
+        );
+
+        setDialogue(getKey(
+          GameScenes.Scene_01,
+          GameStages.Stage_02,
+          CutSceneDestinationIdentifier.Guard),
+          new string[] {
+            "Why are you here?", // First index is the queston / title
+            "I'm an enlisted footman sent here.",
+            "I don't know why I'm here"
+          },
+          new System.Action[] {
+            () => Debug.Log("Chose 1"),
+            () => Debug.Log("Chose 2")
+          }
+        );
+
+        setDialogue(getKey(
+          GameScenes.Scene_01,
+          GameStages.Stage_03,
+          CutSceneDestinationIdentifier.Guard),
+          new string[] {"Well, we'll see about that won't we?"}
+        );
+
+        // WIZARD
+      }
+
+      private void testDialogue() {
         setDialogue(getKey(
           GameScenes.Scene_01,
           GameStages.Stage_01,
@@ -81,20 +156,6 @@ namespace Game.Story
           CutSceneDestinationIdentifier.Wizard),
           new string[] {"I have new text cause its the second scene!!"}
         );
-
-        //Useful for debugging
-        /*Debug.Log("KEYS:");
-        foreach (string key in text.Keys) {
-          Debug.Log(key);
-        }*/
-      }
-
-      private void setDialogue(string key, string[] dialogue, System.Action[] dialogueActions = null) {
-        text.Add(key, dialogue);
-
-        if (dialogueActions != null) {
-          actions.Add(key, dialogueActions);
-        }
       }
     }
 }

--- a/Assets/Scripts/Enums/Enums.cs
+++ b/Assets/Scripts/Enums/Enums.cs
@@ -18,7 +18,8 @@ namespace Game.Enums
     public enum CutSceneDestinationIdentifier
     {
         Wizard,
-        EvilWizard
+        EvilWizard,
+        Guard,
     }
 
     public enum GameScenes

--- a/Assets/Scripts/NPC/GuardManager.cs
+++ b/Assets/Scripts/NPC/GuardManager.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Game.Story;
+using Game.Control;
+using Game.Enums;
+using Game.SceneManagement;
+
+namespace Game.NPC
+{
+    public class GuardManager : MonoBehaviour, IRaycastable
+    {
+        [SerializeField] GameObject interactionIndicatorUI = null;
+
+        DialogueManager dialogue;
+        private bool isKeyActive = false;
+        private bool isRaycastOn = false;
+        
+        private void OnEnable()
+        {
+            EventHandler.InteractActionKeyEvent += InteractActionActivateGuard;
+        }
+        private void OnDisable()
+        {
+            EventHandler.InteractActionKeyEvent -= InteractActionActivateGuard;
+        }
+
+        private void Update() 
+        {
+            InteractUIDisplay();
+            isRaycastOn = false;
+        }
+        public void InteractUIDisplay()
+        {
+            if(!interactionIndicatorUI) return;
+            interactionIndicatorUI.SetActive(isRaycastOn);
+        }
+
+        public bool HandleRaycast(PlayerInputControl callingController)
+        {
+            isRaycastOn = true;
+
+            if(isKeyActive)
+            {
+                Debug.Log("Activate Guard");
+
+                EventHandler.CallDialogueActionEvent(CutSceneDestinationIdentifier.Guard);
+            }
+
+            EventHandler.CallInteractActionKeyEvent(false);
+
+            return true;
+        }
+
+        private void InteractActionActivateGuard(bool isKeyPressed)
+        {
+            isKeyActive = isKeyPressed;
+        }
+
+    }
+    
+}

--- a/Assets/Scripts/NPC/GuardManager.cs.meta
+++ b/Assets/Scripts/NPC/GuardManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 173c1e9a6ade34238a345732113e1359
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
We now have the ability to step through the dialogue using an optional `next` button.

![Screen Shot 2022-03-18 at 10 05 18 PM](https://user-images.githubusercontent.com/527740/159104718-36446135-777f-417a-b539-716d566feeca.png)

Also improved the selection screen so that it shows the question at the top of the choices, you don't have to put the question before the choices anymore.

![Screen Shot 2022-03-18 at 10 07 11 PM](https://user-images.githubusercontent.com/527740/159104735-c2a65eaa-0a09-4572-8bc4-7e852c671415.png)

If you visit the black diamond, it will trigger the scene 1 guard dialogue.

![Screen Shot 2022-03-18 at 10 19 57 PM](https://user-images.githubusercontent.com/527740/159104771-41de9338-8190-430b-8c75-7b4ff64e8a0e.png)

